### PR TITLE
add trailing slash

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -56,19 +56,19 @@ http {
 			proxy_redirect off;
 		}
 
-	location /blog/ {
-      		resolver 1.1.1.1 valid=30s;
-      		resolver_timeout 30s;
-      		proxy_pass https://wp.territoryfoods.com/;
-			proxy_redirect off;
-		}
-
-	location /blog {
-		resolver 1.1.1.1 valid=30s;
-		resolver_timeout 30s;
-		proxy_pass https://wp.territoryfoods.com;
-		proxy_redirect off;
-
-	}
+    location /blog/ {
+      resolver 1.1.1.1 valid=30s;
+      resolver_timeout 30s;
+      proxy_pass https://wp.territoryfoods.com/;
+      proxy_redirect off;
+    }
+    
+    # In order to prevent a 301, /blog needs to be defined explicitly
+    location /blog {
+      resolver 1.1.1.1 valid=30s;
+      resolver_timeout 30s;
+      proxy_pass https://wp.territoryfoods.com/;
+      proxy_redirect off;
+    }
   }
 }


### PR DESCRIPTION
A trailing slash is required on the proxy pass in order for the URIs to append properly. 
See documentation here: 
http://nginx.org/en/docs/http/ngx_http_core_module.html#location

Specific reasoning as to why `/blog` will 301 instead of proxying: 

`If a location is defined by a prefix string that ends with the slash character, and requests are processed by one of proxy_pass, fastcgi_pass, uwsgi_pass, scgi_pass, memcached_pass, or grpc_pass, then the special processing is performed. In response to a request with URI equal to this string, but without the trailing slash, a permanent redirect with the code 301 will be returned to the requested URI with the slash appended. If this is not desired, an exact match of the URI and location could be defined like this:`
  ```
location /user/ {
      proxy_pass http://user.example.com;
  }
  
  location = /user {
      proxy_pass http://login.example.com;
  }
```

